### PR TITLE
Fix Cloudwatch client usage

### DIFF
--- a/lib/src/check_alarm_status_lambda/index.py
+++ b/lib/src/check_alarm_status_lambda/index.py
@@ -37,7 +37,8 @@ def lambda_handler(event, context):
         logger.info(alarm_tags)
         if check_if_repeated_alarm_enabled(alarm_tags.get("Tags")):
             alarm_response = CW_CLIENT.describe_alarms(
-                AlarmNames=[alarm_name]
+                AlarmNames=[alarm_name],
+                AlarmTypes=["CompositeAlarm", "MetricAlarm"]
             )
             logger.info(alarm_response)
 


### PR DESCRIPTION
*Issue #, if available:*
With current setup solution is always failing on CompositeAlarms as they are not returned

*Description of changes:*
Fixed usage of Cloudwatch SDK

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
